### PR TITLE
Use SSL for GitHub API

### DIFF
--- a/lib/octopi.rb
+++ b/lib/octopi.rb
@@ -76,7 +76,7 @@ module Octopi
     }
     
     # Login with the provided 
-    a.get('http://github.com/login') do |page|
+    a.get('https://github.com/login') do |page|
       user_page = page.form_with(:action => '/session') do |login|
         login.login = username
         login.password = password

--- a/lib/octopi.rb
+++ b/lib/octopi.rb
@@ -1,5 +1,7 @@
 require 'rubygems'
 
+require 'open-uri'
+
 require 'httparty'
 require 'mechanize'
 require 'nokogiri'
@@ -7,6 +9,7 @@ require 'api_cache'
 
 require 'yaml'
 require 'pp'
+
 
 # Core extension stuff
 Dir[File.join(File.dirname(__FILE__), "ext/*.rb")].each { |f| require f }

--- a/lib/octopi/api.rb
+++ b/lib/octopi/api.rb
@@ -166,6 +166,7 @@ module Octopi
       # Ergh. Ugly way to do this. Find a better one!
       cache = params.delete(:cache) 
       cache = true if cache.nil?
+      cache = false
       params.each_pair do |k,v|
         if path =~ /:#{k.to_s}/
           params.delete(k)

--- a/lib/octopi/api.rb
+++ b/lib/octopi/api.rb
@@ -11,7 +11,7 @@ module Octopi
   class AnonymousApi < Api
     include HTTParty
     include Singleton
-    base_uri "http://github.com/api/v2"
+    base_uri "https://github.com/api/v2"
     
     def read_only?
       true

--- a/lib/octopi/gist.rb
+++ b/lib/octopi/gist.rb
@@ -10,7 +10,7 @@ module Octopi
     resource_path ":id"
     
     def self.base_uri
-      "http://gist.github.com/api/v1/yaml"
+      "https://gist.github.com/api/v1/yaml"
     end
     
     def self.find(id)

--- a/lib/octopi/repository.rb
+++ b/lib/octopi/repository.rb
@@ -45,7 +45,7 @@ module Octopi
       # We have to specify xmlns as a prefix as the document is namespaced.
       # Be wary!
       path = "https://github.com/#{owner}/#{name}/comments.atom"
-      xml = Nokogiri::XML(Net::HTTP.get(URI.parse(path)))
+      xml = Nokogiri::XML(open(URI.parse(path)))
       entries = xml.xpath("//xmlns:entry")
       comments = []
       for entry in entries

--- a/lib/octopi/repository.rb
+++ b/lib/octopi/repository.rb
@@ -44,7 +44,7 @@ module Octopi
     def comments
       # We have to specify xmlns as a prefix as the document is namespaced.
       # Be wary!
-      path = "http#{'s' if private}://github.com/#{owner}/#{name}/comments.atom"
+      path = "https://github.com/#{owner}/#{name}/comments.atom"
       xml = Nokogiri::XML(Net::HTTP.get(URI.parse(path)))
       entries = xml.xpath("//xmlns:entry")
       comments = []

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -17,7 +17,7 @@ class RepositoryTest < Test::Unit::TestCase
   context Repository do
     
     should "not retry for a repository you don't have access to" do
-      FakeWeb.register_uri(:get, "#{yaml_api}/repos/show/github/github", :status => 403)
+      FakeWeb.register_uri(:get, "https://#{yaml_api}/repos/show/github/github", :status => 403)
       
       exception = assert_raise APIError do
         Repository.find(:user => "github", :name => "github")

--- a/test/stubs/commits/fcoury/octopi/master
+++ b/test/stubs/commits/fcoury/octopi/master
@@ -8,7 +8,7 @@ Status: 200 OK
 X-Runtime: 2142ms
 ETag: "d6c1ad29c54bc9c0be806941e22faeb3"
 Cache-Control: private, max-age=0, must-revalidate
-Content-Length: 16571
+Content-Length: 16601
 
 --- 
 commits: 
@@ -18,7 +18,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 737650490a3cf3689f92644126407b21c4493d9a
-  url: http://github.com/fcoury/octopi/commit/f6609209c3ac0badd004512d318bfaa508ea10ae
+  url: https://github.com/fcoury/octopi/commit/f6609209c3ac0badd004512d318bfaa508ea10ae
   author: 
     name: Andrew Moreland
     email: andy@andymo.org
@@ -32,7 +32,7 @@ commits:
 - message: Regenerated gemspec for version 0.1.0
   parents: 
   - id: 5b71e51b19ce6cb4eda9f6045fa0305bddf3744a
-  url: http://github.com/fcoury/octopi/commit/737650490a3cf3689f92644126407b21c4493d9a
+  url: https://github.com/fcoury/octopi/commit/737650490a3cf3689f92644126407b21c4493d9a
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -46,7 +46,7 @@ commits:
 - message: Version bump to 0.1.0
   parents: 
   - id: 57da65035236b8603c96866f0d5876c6cfe63e46
-  url: http://github.com/fcoury/octopi/commit/5b71e51b19ce6cb4eda9f6045fa0305bddf3744a
+  url: https://github.com/fcoury/octopi/commit/5b71e51b19ce6cb4eda9f6045fa0305bddf3744a
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -60,7 +60,7 @@ commits:
 - message: Sends data in body, not as params (missed Content-Lenght)
   parents: 
   - id: 00fd8079dd423c2028a8a62e98a759c4e49258f9
-  url: http://github.com/fcoury/octopi/commit/57da65035236b8603c96866f0d5876c6cfe63e46
+  url: https://github.com/fcoury/octopi/commit/57da65035236b8603c96866f0d5876c6cfe63e46
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -77,7 +77,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: f7e92f4a5b86141493bd89b2be39a70d03aab3d0
-  url: http://github.com/fcoury/octopi/commit/00fd8079dd423c2028a8a62e98a759c4e49258f9
+  url: https://github.com/fcoury/octopi/commit/00fd8079dd423c2028a8a62e98a759c4e49258f9
   author: 
     name: David Dollar
     email: ddollar@gmail.com
@@ -94,7 +94,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: ed07094122888df187a377b0739e25a5b195cc1e
-  url: http://github.com/fcoury/octopi/commit/f7e92f4a5b86141493bd89b2be39a70d03aab3d0
+  url: https://github.com/fcoury/octopi/commit/f7e92f4a5b86141493bd89b2be39a70d03aab3d0
   author: 
     name: David Dollar
     email: ddollar@gmail.com
@@ -111,7 +111,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 7b33a45ad9e535d8ee27069899ed4de7d703a5f8
-  url: http://github.com/fcoury/octopi/commit/ed07094122888df187a377b0739e25a5b195cc1e
+  url: https://github.com/fcoury/octopi/commit/ed07094122888df187a377b0739e25a5b195cc1e
   author: 
     name: David Dollar
     email: ddollar@gmail.com
@@ -128,7 +128,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: c89ddf74c14c18790e54c66c9fb57bf7a21cf5f3
-  url: http://github.com/fcoury/octopi/commit/7b33a45ad9e535d8ee27069899ed4de7d703a5f8
+  url: https://github.com/fcoury/octopi/commit/7b33a45ad9e535d8ee27069899ed4de7d703a5f8
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -145,7 +145,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 5874d02baac961235cd20dff5e97d752983cfe76
-  url: http://github.com/fcoury/octopi/commit/c89ddf74c14c18790e54c66c9fb57bf7a21cf5f3
+  url: https://github.com/fcoury/octopi/commit/c89ddf74c14c18790e54c66c9fb57bf7a21cf5f3
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -162,7 +162,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 79d9d527ceb4a87476b5c5cafd658a4d5d4b14f0
-  url: http://github.com/fcoury/octopi/commit/5874d02baac961235cd20dff5e97d752983cfe76
+  url: https://github.com/fcoury/octopi/commit/5874d02baac961235cd20dff5e97d752983cfe76
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -176,7 +176,7 @@ commits:
 - message: Build new gem
   parents: 
   - id: 40b809a0bc3d8c71633f9947dd1f1eaeee43dbb5
-  url: http://github.com/fcoury/octopi/commit/79d9d527ceb4a87476b5c5cafd658a4d5d4b14f0
+  url: https://github.com/fcoury/octopi/commit/79d9d527ceb4a87476b5c5cafd658a4d5d4b14f0
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -190,7 +190,7 @@ commits:
 - message: Version bump to 0.0.11
   parents: 
   - id: f07ee115abeecc1a3d852efc7d3d04877af01373
-  url: http://github.com/fcoury/octopi/commit/40b809a0bc3d8c71633f9947dd1f1eaeee43dbb5
+  url: https://github.com/fcoury/octopi/commit/40b809a0bc3d8c71633f9947dd1f1eaeee43dbb5
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -204,7 +204,7 @@ commits:
 - message: Uses http for non private commits calls and https for private commits calls.
   parents: 
   - id: 21678ec8571a5f4ecb847a1d93d830d09cde9b68
-  url: http://github.com/fcoury/octopi/commit/f07ee115abeecc1a3d852efc7d3d04877af01373
+  url: https://github.com/fcoury/octopi/commit/f07ee115abeecc1a3d852efc7d3d04877af01373
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -218,7 +218,7 @@ commits:
 - message: Fixes authorised calls to use https and adds api.commits
   parents: 
   - id: 2bfa90160808b4d7ed281e5858164dc8029509bc
-  url: http://github.com/fcoury/octopi/commit/21678ec8571a5f4ecb847a1d93d830d09cde9b68
+  url: https://github.com/fcoury/octopi/commit/21678ec8571a5f4ecb847a1d93d830d09cde9b68
   author: 
     name: philnash
     email: philnash@gmail.com
@@ -235,7 +235,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: fb5ba554b2d147f8dd62c12ac1dfce1608c2a850
-  url: http://github.com/fcoury/octopi/commit/2bfa90160808b4d7ed281e5858164dc8029509bc
+  url: https://github.com/fcoury/octopi/commit/2bfa90160808b4d7ed281e5858164dc8029509bc
   author: 
     name: Nat Budin
     email: natbudin@gmail.com
@@ -252,7 +252,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 3283fa78014bf066c36e5c1dea1a5dae18fec157
-  url: http://github.com/fcoury/octopi/commit/fb5ba554b2d147f8dd62c12ac1dfce1608c2a850
+  url: https://github.com/fcoury/octopi/commit/fb5ba554b2d147f8dd62c12ac1dfce1608c2a850
   author: 
     name: Nat Budin
     email: natbudin@gmail.com
@@ -269,7 +269,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 524a35d0f61ff6a2d3ba9422bc03e70f5784c679
-  url: http://github.com/fcoury/octopi/commit/3283fa78014bf066c36e5c1dea1a5dae18fec157
+  url: https://github.com/fcoury/octopi/commit/3283fa78014bf066c36e5c1dea1a5dae18fec157
   author: 
     name: Michael Wright
     email: mwright@24-iMac-Workstation.local
@@ -283,7 +283,7 @@ commits:
 - message: Added HTTParty 0.4 as a dependency
   parents: 
   - id: 2f7b98cf531f6e854c4d6efb11adceaef72887ab
-  url: http://github.com/fcoury/octopi/commit/524a35d0f61ff6a2d3ba9422bc03e70f5784c679
+  url: https://github.com/fcoury/octopi/commit/524a35d0f61ff6a2d3ba9422bc03e70f5784c679
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -300,7 +300,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 39a2e5861a8d9685225a3b4214bf521a15e3379f
-  url: http://github.com/fcoury/octopi/commit/2f7b98cf531f6e854c4d6efb11adceaef72887ab
+  url: https://github.com/fcoury/octopi/commit/2f7b98cf531f6e854c4d6efb11adceaef72887ab
   author: 
     name: serega
     email: martynovs@gmail.com
@@ -317,7 +317,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 732d22de1a375f92d24c80c989be0a6d08c301b0
-  url: http://github.com/fcoury/octopi/commit/39a2e5861a8d9685225a3b4214bf521a15e3379f
+  url: https://github.com/fcoury/octopi/commit/39a2e5861a8d9685225a3b4214bf521a15e3379f
   author: 
     name: Nat Budin
     email: natbudin@gmail.com
@@ -334,7 +334,7 @@ commits:
     Signed-off-by: Felipe Coury <felipe.coury@gmail.com>
   parents: 
   - id: 0a1410ea8125dae0b308303cbd840037cc88a633
-  url: http://github.com/fcoury/octopi/commit/732d22de1a375f92d24c80c989be0a6d08c301b0
+  url: https://github.com/fcoury/octopi/commit/732d22de1a375f92d24c80c989be0a6d08c301b0
   author: 
     name: Adam Maddox
     email: adam.maddox@redcoded.com
@@ -348,7 +348,7 @@ commits:
 - message: Added some more rdoc comments
   parents: 
   - id: 60cef225f9167da76ee21a4e10a6e6a633835c9f
-  url: http://github.com/fcoury/octopi/commit/0a1410ea8125dae0b308303cbd840037cc88a633
+  url: https://github.com/fcoury/octopi/commit/0a1410ea8125dae0b308303cbd840037cc88a633
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -362,7 +362,7 @@ commits:
 - message: Added twitter notification account to README
   parents: 
   - id: eb2634e95308a32951404f70004864c64a94c78a
-  url: http://github.com/fcoury/octopi/commit/60cef225f9167da76ee21a4e10a6e6a633835c9f
+  url: https://github.com/fcoury/octopi/commit/60cef225f9167da76ee21a4e10a6e6a633835c9f
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -376,7 +376,7 @@ commits:
 - message: Added support for RubyForge
   parents: 
   - id: 4cca98dd9cfed5e976629b08b7c8145258e2aaee
-  url: http://github.com/fcoury/octopi/commit/eb2634e95308a32951404f70004864c64a94c78a
+  url: https://github.com/fcoury/octopi/commit/eb2634e95308a32951404f70004864c64a94c78a
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -390,7 +390,7 @@ commits:
 - message: Regenerated gemspec for version 0.0.9
   parents: 
   - id: 1cf985a4197c64acb4ec042d4b605440957daf7b
-  url: http://github.com/fcoury/octopi/commit/4cca98dd9cfed5e976629b08b7c8145258e2aaee
+  url: https://github.com/fcoury/octopi/commit/4cca98dd9cfed5e976629b08b7c8145258e2aaee
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -404,7 +404,7 @@ commits:
 - message: Version bump to 0.0.9
   parents: 
   - id: 3722781bfead75e7c30363f158ee58f8691047cd
-  url: http://github.com/fcoury/octopi/commit/1cf985a4197c64acb4ec042d4b605440957daf7b
+  url: https://github.com/fcoury/octopi/commit/1cf985a4197c64acb4ec042d4b605440957daf7b
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -418,7 +418,7 @@ commits:
 - message: Removed two "puts" leftovers
   parents: 
   - id: abcb268b938318d23b7dea710fb792fbee1c46bc
-  url: http://github.com/fcoury/octopi/commit/3722781bfead75e7c30363f158ee58f8691047cd
+  url: https://github.com/fcoury/octopi/commit/3722781bfead75e7c30363f158ee58f8691047cd
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -432,7 +432,7 @@ commits:
 - message: Regenerated gemspec for version 0.0.8
   parents: 
   - id: b0d16c6a862a23d3ba50770ba9f29b63ab8aaeca
-  url: http://github.com/fcoury/octopi/commit/abcb268b938318d23b7dea710fb792fbee1c46bc
+  url: https://github.com/fcoury/octopi/commit/abcb268b938318d23b7dea710fb792fbee1c46bc
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -446,7 +446,7 @@ commits:
 - message: Version bump to 0.0.8
   parents: 
   - id: 0a3417a353961c61a7f56818e566d04570c92600
-  url: http://github.com/fcoury/octopi/commit/b0d16c6a862a23d3ba50770ba9f29b63ab8aaeca
+  url: https://github.com/fcoury/octopi/commit/b0d16c6a862a23d3ba50770ba9f29b63ab8aaeca
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com
@@ -464,7 +464,7 @@ commits:
     Added new Key resource to add and remove keys.
   parents: 
   - id: 845fa497497e211944b13485fa596bf46f8f182a
-  url: http://github.com/fcoury/octopi/commit/0a3417a353961c61a7f56818e566d04570c92600
+  url: https://github.com/fcoury/octopi/commit/0a3417a353961c61a7f56818e566d04570c92600
   author: 
     name: Felipe Coury
     email: felipe.coury@gmail.com

--- a/test/stubs/repos/fcoury/octopi/main
+++ b/test/stubs/repos/fcoury/octopi/main
@@ -4,7 +4,7 @@ repository:
   :name: octopi
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/octopi
+  :url: https://github.com/fcoury/octopi
   :fork: false
   :forks: 10
   :homepage: http://hasmany.info/2009/4/18/ruby-interface-to-github-api

--- a/test/stubs/repos/fcoury/octopi/master
+++ b/test/stubs/repos/fcoury/octopi/master
@@ -8,7 +8,7 @@ Status: 200 OK
 X-Runtime: 44ms
 ETag: "faa4b600dd11e351c6777caba84cd44a"
 Cache-Control: private, max-age=0, must-revalidate
-Content-Length: 294
+Content-Length: 295
 
 --- 
 repository: 
@@ -17,7 +17,7 @@ repository:
   :name: octopi
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/octopi
+  :url: https://github.com/fcoury/octopi
   :watchers: 80
   :fork: false
   :open_issues: 21

--- a/test/stubs/repos/fcoury/octopus/main
+++ b/test/stubs/repos/fcoury/octopus/main
@@ -8,7 +8,7 @@ Status: 200 OK
 X-Runtime: 11ms
 ETag: "0380b1913d11230f44fce4c21b98227e"
 Cache-Control: private, max-age=0, must-revalidate
-Content-Length: 293
+Content-Length: 294
 
 --- 
 repository: 
@@ -16,7 +16,7 @@ repository:
   :name: octopus
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/octopus
+  :url: https://github.com/fcoury/octopus
   :fork: false
   :forks: 0
   :homepage: http://hasmany.info/2009/4/18/ruby-interface-to-github-api

--- a/test/stubs/repos/fcoury/rboard/main
+++ b/test/stubs/repos/fcoury/rboard/main
@@ -4,7 +4,7 @@ repository:
   :name: rboard
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rboard
+  :url: https://github.com/fcoury/rboard
   :fork: true
   :forks: 10
   :homepage: http://frozenplague.net

--- a/test/stubs/repos/fcoury/rboard/master
+++ b/test/stubs/repos/fcoury/rboard/master
@@ -8,7 +8,7 @@ Status: 200 OK
 X-Runtime: 44ms
 ETag: "faa4b600dd11e351c6777caba84cd44a"
 Cache-Control: private, max-age=0, must-revalidate
-Content-Length: 248
+Content-Length: 249
 
 --- 
 repository: 
@@ -16,7 +16,7 @@ repository:
   :name: rboard
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rboard
+  :url: https://github.com/fcoury/rboard
   :fork: true
   :forks: 10
   :homepage: http://frozenplague.net

--- a/test/stubs/repos/show/fcoury
+++ b/test/stubs/repos/show/fcoury
@@ -8,7 +8,7 @@ Status: 200 OK
 X-Runtime: 732ms
 ETag: "49ecb439a63faeb94f8e84228123fcb8"
 Cache-Control: private, max-age=0, must-revalidate
-Content-Length: 12196
+Content-Length: 12241
 
 --- 
 repositories: 
@@ -17,7 +17,7 @@ repositories:
   :name: labelbug
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/labelbug
+  :url: https://github.com/fcoury/labelbug
   :watchers: 2
   :fork: false
   :open_issues: 0
@@ -27,7 +27,7 @@ repositories:
   :name: web-app-theme
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/web-app-theme
+  :url: https://github.com/fcoury/web-app-theme
   :watchers: 2
   :fork: true
   :open_issues: 0
@@ -37,7 +37,7 @@ repositories:
   :name: autumn
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/autumn
+  :url: https://github.com/fcoury/autumn
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -47,7 +47,7 @@ repositories:
   :name: baseapp
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/baseapp
+  :url: https://github.com/fcoury/baseapp
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -57,7 +57,7 @@ repositories:
   :name: warehouse
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/warehouse
+  :url: https://github.com/fcoury/warehouse
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -67,7 +67,7 @@ repositories:
   :name: dotfiles
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/dotfiles
+  :url: https://github.com/fcoury/dotfiles
   :watchers: 2
   :fork: false
   :open_issues: 0
@@ -77,7 +77,7 @@ repositories:
   :name: cucumber
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/cucumber
+  :url: https://github.com/fcoury/cucumber
   :watchers: 2
   :fork: true
   :open_issues: 0
@@ -87,7 +87,7 @@ repositories:
   :name: titleizer
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/titleizer
+  :url: https://github.com/fcoury/titleizer
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -97,7 +97,7 @@ repositories:
   :name: chef
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/chef
+  :url: https://github.com/fcoury/chef
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -107,7 +107,7 @@ repositories:
   :name: simple_auto_complete
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/simple_auto_complete
+  :url: https://github.com/fcoury/simple_auto_complete
   :watchers: 2
   :fork: true
   :open_issues: 0
@@ -117,7 +117,7 @@ repositories:
   :name: rbcurse
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rbcurse
+  :url: https://github.com/fcoury/rbcurse
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -127,7 +127,7 @@ repositories:
   :name: jfilehelpers
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/jfilehelpers
+  :url: https://github.com/fcoury/jfilehelpers
   :watchers: 2
   :fork: false
   :open_issues: 0
@@ -137,7 +137,7 @@ repositories:
   :name: api_cache
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/api_cache
+  :url: https://github.com/fcoury/api_cache
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -147,7 +147,7 @@ repositories:
   :name: fakeweb
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/fakeweb
+  :url: https://github.com/fcoury/fakeweb
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -157,7 +157,7 @@ repositories:
   :name: hirb-isolated
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/hirb-isolated
+  :url: https://github.com/fcoury/hirb-isolated
   :watchers: 1
   :fork: false
   :open_issues: 0
@@ -167,7 +167,7 @@ repositories:
   :name: db2s3
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/db2s3
+  :url: https://github.com/fcoury/db2s3
   :watchers: 2
   :fork: true
   :open_issues: 0
@@ -177,7 +177,7 @@ repositories:
   :name: vimfiles
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/vimfiles
+  :url: https://github.com/fcoury/vimfiles
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -187,7 +187,7 @@ repositories:
   :name: blueprint
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/blueprint
+  :url: https://github.com/fcoury/blueprint
   :watchers: 1
   :fork: false
   :open_issues: 0
@@ -196,7 +196,7 @@ repositories:
   :name: taps
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/taps
+  :url: https://github.com/fcoury/taps
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -206,7 +206,7 @@ repositories:
   :name: cucumber-tmbundle
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/cucumber-tmbundle
+  :url: https://github.com/fcoury/cucumber-tmbundle
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -216,7 +216,7 @@ repositories:
   :name: sinatra-template
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/sinatra-template
+  :url: https://github.com/fcoury/sinatra-template
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -226,7 +226,7 @@ repositories:
   :name: cursoprevestibular
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/cursoprevestibular
+  :url: https://github.com/fcoury/cursoprevestibular
   :watchers: 1
   :fork: false
   :open_issues: 0
@@ -236,7 +236,7 @@ repositories:
   :name: octopi
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/octopi
+  :url: https://github.com/fcoury/octopi
   :watchers: 80
   :fork: false
   :open_issues: 21
@@ -246,7 +246,7 @@ repositories:
   :name: bucketwise
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/bucketwise
+  :url: https://github.com/fcoury/bucketwise
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -256,7 +256,7 @@ repositories:
   :name: api-labrat
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/api-labrat
+  :url: https://github.com/fcoury/api-labrat
   :watchers: 1
   :fork: false
   :open_issues: 2
@@ -266,7 +266,7 @@ repositories:
   :name: backup_fu
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/backup_fu
+  :url: https://github.com/fcoury/backup_fu
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -276,7 +276,7 @@ repositories:
   :name: git_remote_branch
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/git_remote_branch
+  :url: https://github.com/fcoury/git_remote_branch
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -286,7 +286,7 @@ repositories:
   :name: rails-sti-caching
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rails-sti-caching
+  :url: https://github.com/fcoury/rails-sti-caching
   :watchers: 1
   :fork: false
   :open_issues: 0
@@ -296,7 +296,7 @@ repositories:
   :name: eff-the-finder
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/eff-the-finder
+  :url: https://github.com/fcoury/eff-the-finder
   :watchers: 2
   :fork: true
   :open_issues: 0
@@ -306,7 +306,7 @@ repositories:
   :name: open_gem
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/open_gem
+  :url: https://github.com/fcoury/open_gem
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -316,7 +316,7 @@ repositories:
   :name: html_tag
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/html_tag
+  :url: https://github.com/fcoury/html_tag
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -326,7 +326,7 @@ repositories:
   :name: sinatra-oauth-provider
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/sinatra-oauth-provider
+  :url: https://github.com/fcoury/sinatra-oauth-provider
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -336,7 +336,7 @@ repositories:
   :name: oauth_provider
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/oauth_provider
+  :url: https://github.com/fcoury/oauth_provider
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -346,7 +346,7 @@ repositories:
   :name: oauth_sample
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/oauth_sample
+  :url: https://github.com/fcoury/oauth_sample
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -356,7 +356,7 @@ repositories:
   :name: sprinkle
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/sprinkle
+  :url: https://github.com/fcoury/sprinkle
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -366,7 +366,7 @@ repositories:
   :name: scripts1
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/scripts1
+  :url: https://github.com/fcoury/scripts1
   :watchers: 1
   :fork: false
   :open_issues: 0
@@ -376,7 +376,7 @@ repositories:
   :name: scripts
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/scripts
+  :url: https://github.com/fcoury/scripts
   :watchers: 1
   :fork: false
   :open_issues: 0
@@ -386,7 +386,7 @@ repositories:
   :name: gitready
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/gitready
+  :url: https://github.com/fcoury/gitready
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -396,7 +396,7 @@ repositories:
   :name: affiliate_links
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/affiliate_links
+  :url: https://github.com/fcoury/affiliate_links
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -406,7 +406,7 @@ repositories:
   :name: ruport
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/ruport
+  :url: https://github.com/fcoury/ruport
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -416,7 +416,7 @@ repositories:
   :name: mongomapper
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/mongomapper
+  :url: https://github.com/fcoury/mongomapper
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -426,7 +426,7 @@ repositories:
   :name: aprilchild
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/aprilchild
+  :url: https://github.com/fcoury/aprilchild
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -436,7 +436,7 @@ repositories:
   :name: bj-utc
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/bj-utc
+  :url: https://github.com/fcoury/bj-utc
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -446,7 +446,7 @@ repositories:
   :name: github_hook_server
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/github_hook_server
+  :url: https://github.com/fcoury/github_hook_server
   :watchers: 1
   :fork: true
   :open_issues: 0
@@ -456,7 +456,7 @@ repositories:
   :name: rabbit_starter
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rabbit_starter
+  :url: https://github.com/fcoury/rabbit_starter
   :watchers: 2
   :fork: true
   :open_issues: 0

--- a/test/stubs/repos/show/fcoury-private
+++ b/test/stubs/repos/show/fcoury-private
@@ -8,7 +8,7 @@ Status: 200 OK
 X-Runtime: 44ms
 ETag: "faa4b600dd11e351c6777caba84cd44a"
 Cache-Control: private, max-age=0, must-revalidate
-Content-Length: 11741
+Content-Length: 11785
 
 
 --- 
@@ -17,7 +17,7 @@ repositories:
   :name: labelbug
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/labelbug
+  :url: https://github.com/fcoury/labelbug
   :fork: false
   :forks: 0
   :homepage: http://labelbug.felipecoury.com
@@ -27,7 +27,7 @@ repositories:
   :name: web-app-theme
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/web-app-theme
+  :url: https://github.com/fcoury/web-app-theme
   :fork: true
   :forks: 0
   :homepage: ""
@@ -37,7 +37,7 @@ repositories:
   :name: autumn
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/autumn
+  :url: https://github.com/fcoury/autumn
   :fork: true
   :forks: 0
   :homepage: http://autumn-orm.org/
@@ -47,7 +47,7 @@ repositories:
   :name: baseapp
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/baseapp
+  :url: https://github.com/fcoury/baseapp
   :fork: true
   :forks: 0
   :homepage: http://baseapp.org
@@ -57,7 +57,7 @@ repositories:
   :name: warehouse
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/warehouse
+  :url: https://github.com/fcoury/warehouse
   :fork: true
   :forks: 0
   :homepage: http://warehouseapp.com
@@ -67,7 +67,7 @@ repositories:
   :name: dotfiles
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/dotfiles
+  :url: https://github.com/fcoury/dotfiles
   :fork: false
   :forks: 0
   :homepage: http://fcoury.info
@@ -77,7 +77,7 @@ repositories:
   :name: cucumber
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/cucumber
+  :url: https://github.com/fcoury/cucumber
   :fork: true
   :forks: 0
   :homepage: http://github.com/aslakhellesoy/cucumber/wikis
@@ -87,7 +87,7 @@ repositories:
   :name: titleizer
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/titleizer
+  :url: https://github.com/fcoury/titleizer
   :fork: true
   :forks: 0
   :homepage: ""
@@ -97,7 +97,7 @@ repositories:
   :name: chef
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/chef
+  :url: https://github.com/fcoury/chef
   :fork: true
   :forks: 0
   :homepage: http://wiki.opscode.com/display/chef
@@ -107,7 +107,7 @@ repositories:
   :name: simple_auto_complete
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/simple_auto_complete
+  :url: https://github.com/fcoury/simple_auto_complete
   :fork: true
   :forks: 0
   :homepage: http://pragmatig.wordpress.com/2008/04/25/unobtrusive-autocomplete-rails-plugin/
@@ -117,7 +117,7 @@ repositories:
   :name: rbcurse
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rbcurse
+  :url: https://github.com/fcoury/rbcurse
   :fork: true
   :forks: 0
   :homepage: http://totalrecall.wordpress.com/
@@ -127,7 +127,7 @@ repositories:
   :name: jfilehelpers
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/jfilehelpers
+  :url: https://github.com/fcoury/jfilehelpers
   :fork: false
   :forks: 0
   :homepage: http://jfilehelpers.com
@@ -137,7 +137,7 @@ repositories:
   :name: api_cache
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/api_cache
+  :url: https://github.com/fcoury/api_cache
   :fork: true
   :forks: 0
   :homepage: ""
@@ -147,7 +147,7 @@ repositories:
   :name: fakeweb
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/fakeweb
+  :url: https://github.com/fcoury/fakeweb
   :fork: true
   :forks: 0
   :homepage: http://groups.google.com/group/fakeweb-users
@@ -157,7 +157,7 @@ repositories:
   :name: hirb-isolated
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/hirb-isolated
+  :url: https://github.com/fcoury/hirb-isolated
   :fork: false
   :forks: 0
   :homepage: ""
@@ -167,7 +167,7 @@ repositories:
   :name: db2s3
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/db2s3
+  :url: https://github.com/fcoury/db2s3
   :fork: true
   :forks: 1
   :homepage: ""
@@ -177,7 +177,7 @@ repositories:
   :name: vimfiles
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/vimfiles
+  :url: https://github.com/fcoury/vimfiles
   :fork: true
   :forks: 0
   :homepage: ""
@@ -187,7 +187,7 @@ repositories:
   :name: blueprint
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/blueprint
+  :url: https://github.com/fcoury/blueprint
   :fork: false
   :forks: 0
   :watchers: 1
@@ -196,7 +196,7 @@ repositories:
   :name: taps
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/taps
+  :url: https://github.com/fcoury/taps
   :fork: true
   :forks: 0
   :homepage: ""
@@ -206,7 +206,7 @@ repositories:
   :name: cucumber-tmbundle
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/cucumber-tmbundle
+  :url: https://github.com/fcoury/cucumber-tmbundle
   :fork: true
   :forks: 0
   :homepage: http://www.benmabey.com
@@ -216,7 +216,7 @@ repositories:
   :name: sinatra-template
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/sinatra-template
+  :url: https://github.com/fcoury/sinatra-template
   :fork: true
   :forks: 0
   :homepage: ""
@@ -226,7 +226,7 @@ repositories:
   :name: cursoprevestibular
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/cursoprevestibular
+  :url: https://github.com/fcoury/cursoprevestibular
   :fork: false
   :forks: 0
   :homepage: ""
@@ -236,7 +236,7 @@ repositories:
   :name: octopi
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/octopi
+  :url: https://github.com/fcoury/octopi
   :fork: false
   :forks: 10
   :homepage: http://hasmany.info/2009/4/18/ruby-interface-to-github-api
@@ -246,7 +246,7 @@ repositories:
   :name: bucketwise
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/bucketwise
+  :url: https://github.com/fcoury/bucketwise
   :fork: true
   :forks: 0
   :homepage: ""
@@ -256,7 +256,7 @@ repositories:
   :name: api-labrat
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/api-labrat
+  :url: https://github.com/fcoury/api-labrat
   :fork: false
   :forks: 0
   :homepage: http://github.com/fcoury/octopi
@@ -266,7 +266,7 @@ repositories:
   :name: backup_fu
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/backup_fu
+  :url: https://github.com/fcoury/backup_fu
   :fork: true
   :forks: 0
   :homepage: http://shanti.railsblog.com/backup-fu-makes-amazon-s3-backups-redonkulous
@@ -276,7 +276,7 @@ repositories:
   :name: git_remote_branch
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/git_remote_branch
+  :url: https://github.com/fcoury/git_remote_branch
   :fork: true
   :forks: 0
   :homepage: http://grb.rubyforge.org/
@@ -286,7 +286,7 @@ repositories:
   :name: rails-sti-caching
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/rails-sti-caching
+  :url: https://github.com/fcoury/rails-sti-caching
   :fork: false
   :forks: 0
   :homepage: ""
@@ -296,7 +296,7 @@ repositories:
   :name: eff-the-finder
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/eff-the-finder
+  :url: https://github.com/fcoury/eff-the-finder
   :fork: true
   :forks: 0
   :homepage: ""
@@ -306,7 +306,7 @@ repositories:
   :name: open_gem
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/open_gem
+  :url: https://github.com/fcoury/open_gem
   :fork: true
   :forks: 0
   :homepage: http://endofline.wordpress.com
@@ -316,7 +316,7 @@ repositories:
   :name: html_tag
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/html_tag
+  :url: https://github.com/fcoury/html_tag
   :fork: true
   :forks: 0
   :homepage: ""
@@ -326,7 +326,7 @@ repositories:
   :name: sinatra-oauth-provider
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/sinatra-oauth-provider
+  :url: https://github.com/fcoury/sinatra-oauth-provider
   :fork: true
   :forks: 0
   :homepage: ""
@@ -336,7 +336,7 @@ repositories:
   :name: oauth_provider
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/oauth_provider
+  :url: https://github.com/fcoury/oauth_provider
   :fork: true
   :forks: 0
   :homepage: ""
@@ -346,7 +346,7 @@ repositories:
   :name: oauth_sample
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/oauth_sample
+  :url: https://github.com/fcoury/oauth_sample
   :fork: true
   :forks: 0
   :homepage: ""
@@ -356,7 +356,7 @@ repositories:
   :name: sprinkle
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/sprinkle
+  :url: https://github.com/fcoury/sprinkle
   :fork: true
   :forks: 0
   :homepage: http://github.com/crafterm/sprinkle
@@ -366,7 +366,7 @@ repositories:
   :name: scripts1
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/scripts1
+  :url: https://github.com/fcoury/scripts1
   :fork: false
   :forks: 0
   :homepage: ""
@@ -376,7 +376,7 @@ repositories:
   :name: scripts
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/scripts
+  :url: https://github.com/fcoury/scripts
   :fork: false
   :forks: 0
   :homepage: ""
@@ -386,7 +386,7 @@ repositories:
   :name: gitready
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/gitready
+  :url: https://github.com/fcoury/gitready
   :fork: true
   :forks: 0
   :homepage: http://gitready.com
@@ -396,7 +396,7 @@ repositories:
   :name: affiliate_links
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/affiliate_links
+  :url: https://github.com/fcoury/affiliate_links
   :fork: true
   :forks: 0
   :homepage: ""
@@ -406,7 +406,7 @@ repositories:
   :name: ruport
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/ruport
+  :url: https://github.com/fcoury/ruport
   :fork: true
   :forks: 0
   :homepage: http://stonecode.svnrepository.com/ruport
@@ -416,7 +416,7 @@ repositories:
   :name: mongomapper
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/mongomapper
+  :url: https://github.com/fcoury/mongomapper
   :fork: true
   :forks: 0
   :homepage: ""
@@ -426,7 +426,7 @@ repositories:
   :name: aprilchild
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/aprilchild
+  :url: https://github.com/fcoury/aprilchild
   :fork: true
   :forks: 0
   :homepage: http://www.aprilchild.com
@@ -436,7 +436,7 @@ repositories:
   :name: bj-utc
   :owner: fcoury
   :private: false
-  :url: http://github.com/fcoury/bj-utc
+  :url: https://github.com/fcoury/bj-utc
   :fork: true
   :forks: 0
   :homepage: ""
@@ -446,7 +446,7 @@ repositories:
   :name: rboard
   :owner: fcoury
   :private: true
-  :url: http://github.com/fcoury/rboard
+  :url: https://github.com/fcoury/rboard
   :fork: false
   :forks: 0
   :homepage: ""

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ def fake_everything
   sha = "f6609209c3ac0badd004512d318bfaa508ea10ae"
   fake_sha = "ea3cd978650417470535f3a4725b6b5042a6ab59"
 
-  plain_api = "github.com:80/api/v2/plain"
+  plain_api = "github.com/api/v2/plain"
   
   # Public stuff
   fakes = {       

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,7 +147,7 @@ def fake_everything
         end
         
   fakes.each do |key, value|
-    FakeWeb.register_uri(:get, "http://#{yaml_api}/" + key, :response => stub_file(value))
+    FakeWeb.register_uri(:get, "https://#{yaml_api}/" + key, :response => stub_file(value))
   end
   
   gist_fakes = {
@@ -156,10 +156,10 @@ def fake_everything
     
     
   gist_fakes.each do |key, value|
-    FakeWeb.register_uri(:get, "http://gist.github.com/api/v1/yaml/#{key}", :response => stub_file(value))
+    FakeWeb.register_uri(:get, "https://gist.github.com/api/v1/yaml/#{key}", :response => stub_file(value))
   end
   ["augustl", "bcalloway", "danlucraft", "dcrec1", "derencius", "dustin", "elliottcable", "gwoliveira", "hashrocket", "jruby", "kchris", "paulorv", "radar", "remi", "shanesveller", "superfeedr", "taylorrf", "tgraham", "tmm1", "tpope", "webbynode"].each do |followee|
-    FakeWeb.register_uri(:get, "http://#{yaml_api}/user/show/#{followee}", :response => stub_file("users/#{followee}") )
+    FakeWeb.register_uri(:get, "https://#{yaml_api}/user/show/#{followee}", :response => stub_file("users/#{followee}") )
   end
   
   
@@ -175,25 +175,25 @@ def fake_everything
     "issues/reopen/fcoury/octopi/27" => issues("27-reopened"),        
     "issues/comment/fcoury/octopi/28" => issues("comment", "28-comment")
   }.each do |key, value|
-    FakeWeb.register_uri(:post, "http://#{yaml_api}/" + key, :response => stub_file(value))
+    FakeWeb.register_uri(:post, "https://#{yaml_api}/" + key, :response => stub_file(value))
   end
   
   # # rboard is a private repository
-  FakeWeb.register_uri(:get, "http://#{yaml_api}/repos/show/fcoury/rboard", :response => stub_file("errors", "repository", "not_found"))
+  FakeWeb.register_uri(:get, "https://#{yaml_api}/repos/show/fcoury/rboard", :response => stub_file("errors", "repository", "not_found"))
   
   # nothere is obviously an invalid sha
-  FakeWeb.register_uri(:get, "http://#{yaml_api}/commits/show/fcoury/octopi/nothere", :status => ["404", "Not Found"])
+  FakeWeb.register_uri(:get, "https://#{yaml_api}/commits/show/fcoury/octopi/nothere", :status => ["404", "Not Found"])
   # not-a-number is obviously not a *number*
-  FakeWeb.register_uri(:get, "http://#{yaml_api}/issues/show/fcoury/octopi/not-a-number", :status => ["404", "Not Found"])
+  FakeWeb.register_uri(:get, "https://#{yaml_api}/issues/show/fcoury/octopi/not-a-number", :status => ["404", "Not Found"])
   # is an invalid hash
-  FakeWeb.register_uri(:get, "http://#{yaml_api}/tree/show/fcoury/octopi/#{fake_sha}", :status => ["404", "Not Found"])
+  FakeWeb.register_uri(:get, "https://#{yaml_api}/tree/show/fcoury/octopi/#{fake_sha}", :status => ["404", "Not Found"])
   # is not a user
-  FakeWeb.register_uri(:get, "http://#{yaml_api}/user/show/i-am-most-probably-a-user-that-does-not-exist", :status => ["404", "Not Found"])
+  FakeWeb.register_uri(:get, "https://#{yaml_api}/user/show/i-am-most-probably-a-user-that-does-not-exist", :status => ["404", "Not Found"])
   
   
-  FakeWeb.register_uri(:get, "http://github.com/login", :response => stub_file("login"))
-  FakeWeb.register_uri(:post, "http://github.com/session", :response => stub_file("dashboard"))
-  FakeWeb.register_uri(:get, "http://github.com/account", :response => stub_file("account"))
+  FakeWeb.register_uri(:get, "https://github.com/login", :response => stub_file("login"))
+  FakeWeb.register_uri(:post, "https://github.com/session", :response => stub_file("dashboard"))
+  FakeWeb.register_uri(:get, "https://github.com/account", :response => stub_file("account"))
   
   # Personal & Private stuff
   
@@ -234,11 +234,11 @@ def fake_everything
     
   
   # And the plain fakes
-  FakeWeb.register_uri(:get, "http://#{plain_api}/blob/show/fcoury/octopi/#{sha}", 
+  FakeWeb.register_uri(:get, "https://#{plain_api}/blob/show/fcoury/octopi/#{sha}",
   :response => stub_file(File.join("blob", "fcoury", "octopi", "plain", sha)))
   
   
-  FakeWeb.register_uri(:get, "http://github.com/fcoury/octopi/comments.atom", :response => stub_file("comments", "fcoury", "octopi", "comments.atom"))
+  FakeWeb.register_uri(:get, "https://github.com/fcoury/octopi/comments.atom", :response => stub_file("comments", "fcoury", "octopi", "comments.atom"))
 end
 
 


### PR DESCRIPTION
Hi, 

I patched octopi to use SSL for all requests to the GitHub API. Unfortunately I had some troubles running the tests successfully. The patch works for me, though.

Benedikt
