### PR TITLE
On repository create, pass user through appropriately if provided.

### DIFF
--- a/lib/octopi/repository.rb
+++ b/lib/octopi/repository.rb
@@ -119,6 +119,10 @@ module Octopi
     def self.create(options={})
       raise AuthenticationRequired, "To create a repository you must be authenticated." if Api.api.read_only?
       self.validate_args(options[:name] => :repo)
+      if options[:user]
+        self.validate_args(options[:user] => :user)
+        options[:name] = "#{options[:user]}/#{options[:name]}"
+      end
       new(Api.api.post(path_for(:create), options.merge( :cache => false ))["repository"])
     end
     

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -113,6 +113,12 @@ class RepositoryTest < Test::Unit::TestCase
       end
     end
     
+    should "be able to create a repository under another user (or organization)" do
+      auth do
+        Repository.create(:name => "octopus", :user => "other-user")
+      end
+    end
+
     should "be able to delete a repository" do
       auth do
         @repository.delete!


### PR DESCRIPTION
This enables creation of repos under organizations you're part of.
