### PR TITLE
Fixed incorrect example 1 for explicit authentication in README. Refs #59

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,8 +31,8 @@ Sometimes, you may not want to get authentication data from _~/.gitconfig_. You 
 
     authenticated_with :login => "mylogin", :token => "mytoken" do 
       repo = Repository.find(:name => "api-labrat", :user => "fcoury")
-      issue = repo.open_issue :title => "Sample issue", 
-        :body => "This issue was opened using GitHub API and Octopi"
+      issue = Issue.open :repo => repo, :params => { 
+        :title => "Sample issue", :body => "This issue was opened using GitHub API and Octopi" }
       puts issue.number
     end
 


### PR DESCRIPTION
The code example in README for explicit authentication was incorrect, as discussed in issue #59. I have changed the code.
